### PR TITLE
update bottom lab pin, simplify some, add maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @afshin @blink1073 @jtpio
+* @afshin @blink1073 @bollwyvl @jtpio

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Development: https://github.com/jupyterlab/retrolab
 
 JupyterLab distribution with a retro look and feel
 
-
 Current build status
 ====================
 
@@ -123,5 +122,6 @@ Feedstock Maintainers
 
 * [@afshin](https://github.com/afshin/)
 * [@blink1073](https://github.com/blink1073/)
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@jtpio](https://github.com/jtpio/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4bf9bfac065d658bdd19c3102917fccf0bae9be0d7c13caa9b9cf176249453f5
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
-{% set name = "retrolab" %}
 {% set version = "0.3.13" %}
-{% set sha256 = "4bf9bfac065d658bdd19c3102917fccf0bae9be0d7c13caa9b9cf176249453f5" %}
 
 package:
-  name: {{ name }}
+  name: retrolab
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/r/retrolab/retrolab-{{ version }}.tar.gz
+  sha256: 4bf9bfac065d658bdd19c3102917fccf0bae9be0d7c13caa9b9cf176249453f5
+
 build:
   number: 0
   noarch: python
@@ -24,7 +23,7 @@ requirements:
 
   run:
     - nbclassic >=0.2,<1
-    - jupyterlab >=3.1.0,<4
+    - jupyterlab >=3.2.0,<4
     - jupyterlab_server >=2.3,<3
     - jupyter_server >=1.4,<2
     - python >=3.6
@@ -45,8 +44,7 @@ about:
   summary: JupyterLab distribution with a retro look and feel
   license: BSD-3-Clause
   license_file: LICENSE
-  description: |
-    JupyterLab distribution with a retro look and feel
+  description: JupyterLab distribution with a retro look and feel
   dev_url: https://github.com/jupyterlab/retrolab
 
 extra:
@@ -54,3 +52,4 @@ extra:
     - jtpio
     - blink1073
     - afshin
+    - bollwyvl


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- bumps the bottom lab pin
  - this is of note, as the current binder version would not be upgraded
- simplify some recipe syntax
- adds self as maintainer :wave: